### PR TITLE
Configure PHPUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
+/coverage-report
 composer.lock
 sample-patl.xlsx

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,3 @@ php:
   - '7.0'
   - hhvm
   - nightly
-script: phpunit --bootstrap=tests/autoload.php tests

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
         }
     ],
     "require": {},
-    "require-dev": {},
+    "require-dev": {
+      "phpunit/phpunit": "5.6.*"
+    },
     "autoload": {
         "psr-4": {
             "haugstrup\\TournamentUtils\\": "src"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,15 @@
+<phpunit bootstrap="tests/autoload.php">
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <log type="coverage-html" target="coverage-report/"/>
+  </logging>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src/</directory>
+    </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
Adding PHPUnit to composer.json
Add phpunit.xml, so that phpunit can be called without args.
Adding a PHPUnit coverage report.