### PR TITLE
Bugfix/head to head swiss pairing

### DIFF
--- a/src/HeadToHeadSwissPairing.php
+++ b/src/HeadToHeadSwissPairing.php
@@ -7,75 +7,82 @@ class HeadToHeadSwissPairing extends Base {
   public $groups = array();
   public $byes = array();
 
+  /*
+    $groups is an array of associative arrays with player ID as the key,
+    and a value of an associative array of opponent IDs as keys and match
+    count as values.  Each array in $groups contains a pool of
+    similarly-matched players (e.g., players with same number of strikes)
+    to pair up for matches.
+    
+    $byes is an associative array of player ID as the key and the number of
+    byes as the value.  This class is OK with $byes containing players that
+    are not also in $groups, and assumes players not present in $byes have
+    zero byes.
+    
+    If there are an odd number of players, this class gives the bye to one
+    of the players with the fewest number of byes.  It then pairs off remaining
+    players group-by-group.  If there are an odd number of players in a group,
+    it will select a player from the next group as the odd player's opponent.
+  */
   public function __construct($groups, $byes = array()) {
     $this->groups = $groups;
-    $this->byes = asort($byes);
+    $this->byes = $byes;
   }
 
   public function build() {
-    $pairings = array();
-    $byes = array();
-    $matched_players = array();
-    $groups = $this->groups;
-
-    // Loop through each sub group
-    for($index=0;$index<count($groups);$index++) {
-      $group = $groups[$index];
-      // If there are only two players, they play each other
-      if (count($group) == 2) {
-        $keys = array_keys($group);
-        $pairings[] = $keys;
-        $matched_players[] = $keys[0];
-        $matched_players[] = $keys[1];
-        continue;
+    $pairings = array();	# array of 2-element arrays of player IDs
+    $byes = array();      # array with ID of player with bye, or empty if no bye
+    
+    # Figure out if we need to pick a player for a bye.
+    $player_count = 0;
+    $player_byes = array();  # assoc. array of player_id => bye_count
+    foreach ($this->groups as $group) {
+      foreach ($group as $player_id => $opponents) {
+        $player_count++;
+        $player_byes[$player_id] = (int)$this->byes[$player_id];
       }
+    }
+    # If there's an odd number of players, select one for the bye
+    if ($player_count % 2) {
+      # choose only from players with the fewest byes
+      $bye_eligible = array_keys($player_byes, min($player_byes));
+      $byes[] = $bye_eligible[array_rand($bye_eligible)];
+    }
 
-      $player_ids = array_keys($group);
-      $player_ids = $this->shuffle($player_ids);
-
-      // For each player
-      foreach ($player_ids as $player_id) {
-        $opponents = $group[$player_id];
-
-        if (in_array($player_id, $matched_players)) {
-          continue;
-        }
-
-        // Build list of available opponents, grouped by number of times played
-        $available_opponents = array();
-        foreach ($group as $opponent_id => $value) {
-          if (!in_array($opponent_id, $matched_players) && $opponent_id != $player_id) {
-            $key = isset($opponents[$opponent_id]) ? $opponents[$opponent_id] : 0;
-            $available_opponents[$key][] = $opponent_id;
+    $match = array();  # 2-element array of player IDs
+    foreach ($this->groups as $group) {
+      $pool = array_keys($group);		# player IDs of current group
+      
+      # remove the "bye" player from the pool if they're in it
+      if (($bye_in_pool = array_search($byes[0], $pool)) !== FALSE) {
+        unset($pool[$bye_in_pool]);
+      }
+      shuffle($pool);
+      while (!empty($pool)) {
+        if (empty($match)) {
+          # select first player for match from shuffled pool
+          $match[] = array_pop($pool);
+        } else {
+          # Select an opponent from those $match[0] has played the least
+          $opponents = array();  # assoc. array of player_id => times_played
+          $past_matches = $group[$match[0]];
+          foreach ($pool as $possible_opponent) {
+            $opponents[$possible_opponent] =
+            	(int) $past_matches[$possible_opponent];
           }
-        }
-        ksort($available_opponents);
-
-        // Go through opponent groups, pick first available player
-        foreach ($available_opponents as $opponent_group) {
-          if (count($opponent_group) > 0) {
-            $random_opponent = $opponent_group[$this->array_rand($opponent_group, 1)];
-
-            $pairings[] = array($player_id, $random_opponent);
-            $matched_players[] = $player_id;
-            $matched_players[] = $random_opponent;
-            break;
-          }
-        }
-
-        // If there are no available opponents, player is moved into the next sub-group
-        if (!in_array($player_id, $matched_players)) {
-          $key = $index+1;
-          if (array_key_exists($key, $groups)) {
-            $groups[$key] = array($player_id => $opponents)+$groups[$key];
-          }
-          else {
-            $byes[] = $player_id;
-            $matched_players[] = $player_id;
-          }
+          # randomly select an opponent from those played least
+          $best_matches = array_keys($opponents, min($opponents));
+          $opponent_id = $best_matches[array_rand($best_matches)];
+          $match[] = $opponent_id;
+          
+          # remove selected opponent from pool
+          unset($pool[array_search($opponent_id, $pool)]);
+          
+          # group completed, create a new matching
+          $pairings[] = $match;
+          $match = array();
         }
       }
-
     }
 
     return array('groups' => $pairings, 'byes' => $byes);

--- a/tests/HeadToHeadSwissPairing.php
+++ b/tests/HeadToHeadSwissPairing.php
@@ -1,0 +1,200 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class HeadToHeadSwissPairingTest extends TestCase {
+
+  /*
+  Helper function, verifies basics:
+    - One bye iif odd number of players.
+    - 2-player groups.
+    - Correct number of 2-player groups.
+    - Player with bye isn't in a group.
+    - No duplicate players in groups.
+  */
+  private function checkResults($count, $pairings) {
+  	$players = array();
+    $this->assertEquals($count % 2, count($pairings['byes']));
+    if ($count % 2) {
+    	$players[$pairings['byes'][0]]++;
+    }
+    $this->assertEquals(floor($count / 2), count($pairings['groups']));
+    foreach ($pairings['groups'] as $group) {
+      $this->assertEquals(2, count($group));
+      foreach ($group as $player_id) {
+      	$players[$player_id]++;
+      }
+    }
+    
+    $this->assertEquals($count, count($players));
+  }
+  
+  # No one should get a bye if there's an even number of players.
+  public function testNoByeForEvenPlayerCount() {
+    $groups = array(
+      array(
+        'Andreas' => array('Per' => 1, 'Darren' => 1),
+        'Per' => array('Matt' => 1, 'Andreas' => 1),
+        'Shon' => array('Sally' => 1, 'Eric' => 1)
+      ),
+      array(
+        'Darren' => array('Andreas' => 1, 'Sally' => 1),
+        'Matt' => array('Per' => 1, 'Eric' => 1),
+        'Eric' => array('Shon' => 1, 'Matt' => 1)
+      )
+    );
+    $byes = array('Andreas' => 1, 'Shon' => 1, 'Darren' => 1, 'Matt' => 1);
+    $builder = new haugstrup\TournamentUtils\HeadToHeadSwissPairing($groups, $byes);
+    
+    for($i=0;$i<100;$i++) {
+      $pairings = $builder->build();
+      $this->checkResults(6, $pairings);
+    }
+  }
+
+  # Simulate round one of a tournament with an even number of players.
+  public function testSingleGroup() {
+    $groups = array(
+      array(
+        'Andreas' => array(),
+        'Per' => array(),
+        'Shon' => array(),
+        'Darren' => array(),
+        'Matt' => array(),
+        'Eric' => array()
+      )
+    );
+    $builder = new haugstrup\TournamentUtils\HeadToHeadSwissPairing($groups);
+    
+    for($i=0;$i<100;$i++) {
+      $pairings = $builder->build();
+      $this->checkResults(6, $pairings);
+    }
+  }
+
+  # Simulate round one of a tournament with an odd number of players.
+  public function testSingleGroupOddCount() {
+    $groups = array(
+      array(
+        'Andreas' => array(),
+        'Per' => array(),
+        'Darren' => array(),
+        'Matt' => array(),
+        'Eric' => array()
+      )
+    );
+    $builder = new haugstrup\TournamentUtils\HeadToHeadSwissPairing($groups);
+    
+    for($i=0;$i<100;$i++) {
+      $pairings = $builder->build();
+      $this->checkResults(5, $pairings);
+    }
+  }
+
+  # Player getting a bye shouldn't have more byes than another player.
+  public function testDuplicateBye() {
+    $groups = array(
+      array(
+        'Andreas' => array('Per' => 1, 'Darren' => 1),
+        'Per' => array('Matt' => 1, 'Andreas' => 1),
+        'Shon' => array('Sally' => 1, 'Eric' => 1)
+      ),
+      array(
+        'Sally' => array('Darren' => 1, 'Shon' => 1),
+        'Darren' => array('Andreas' => 1, 'Sally' => 1),
+        'Matt' => array('Per' => 1, 'Eric' => 1),
+        'Eric' => array('Shon' => 1, 'Matt' => 1)
+      )
+    );
+    $byes = array('Andreas' => 1, 'Shon' => 1, 'Darren' => 1, 'Matt' => 1);
+    $builder = new haugstrup\TournamentUtils\HeadToHeadSwissPairing($groups, $byes);
+    
+    for($i=0;$i<100;$i++) {
+      $pairings = $builder->build();
+      $this->checkResults(7, $pairings);
+      $this->assertFalse(isset($byes[$pairings['byes'][0]]),
+        $pairings['byes'][0] . ' got an extra bye');
+    }
+  }
+
+  # Test for a bug prior to December 2017 where a player with 0 strikes
+  # could get paired with 2-strike player instead of a 1-strike player.
+  public function testJumpedGroup() {
+    $groups = array(
+      array(
+        'PlayerARank0' => array(),
+        'PlayerBRank0' => array(),
+        'PlayerCRank0' => array()
+      ),
+      array(
+        'PlayerARank1' => array(),
+        'PlayerBRank1' => array()
+      ),
+      array(
+        'PlayerARank2' => array()
+      ),
+      array(
+        'PlayerARank3' => array(),
+        'PlayerBRank3' => array(),
+        'PlayerCRank3' => array()
+      ),
+      array(
+        'PlayerARank4' => array(),
+        'PlayerBRank4' => array(),
+        'PlayerCRank4' => array()
+      ),
+      array(
+        'PlayerARank5' => array(),
+        'PlayerBRank5' => array(),
+        'PlayerCRank5' => array()
+      ),
+    );
+    $builder = new haugstrup\TournamentUtils\HeadToHeadSwissPairing($groups);
+    
+    $group_num = 0;
+    global $player_group;
+    $player_group = array();
+    foreach($groups as $players) {
+      foreach($players as $player => $opponents) {
+        $player_group[$player] = $group_num;
+      }
+      $group_num++;
+    }
+    
+    function minrank($cur_rank, $player) {
+      global $player_group;
+      return min($cur_rank, $player_group[$player]);
+    }
+    function maxrank($cur_rank, $player) {
+      global $player_group;
+      return max($cur_rank, $player_group[$player]);
+    }
+    
+    for($i=0;$i<100;$i++) {
+      $pairings = $builder->build();
+      
+      $this->checkResults(15, $pairings);
+      
+      // The min rank of a group must be >= max of prior group.  If not,
+      // a player has jumped through the prior group when making pairings.
+      $prior_min = 0;
+      $prior_max = 0;
+      $prior_group = array();
+      foreach($pairings['groups'] as $group) {
+        $this_min = array_reduce($group, "minrank", 999);
+        $this_max = array_reduce($group, "maxrank", 0);
+        $this->assertGreaterThanOrEqual($prior_max, $this_min,
+          print_r($group, TRUE) . " jumped " . print_r($prior_group, TRUE));
+        $prior_min = $this_min;
+        $prior_max = $this_max;
+        $prior_group = $group;
+      }
+    }
+
+  }
+  
+  // Should write a test to start with an odd number of players and run
+  // through a simulated 10 strike tournament and validate constraints
+  // such as:
+  //   maximum buys - minimum buys <= 1 (no one get a buy until everyone has one)
+  //   test for testJumpedGroup and a bye with an even group of players
+}


### PR DESCRIPTION
This PR addresses issue #1.

It could probably benefit from some more unit tests, especially if tests exist to create dummy tournaments and run them through to completion.

The first commit adds failing unit tests, and the second commit has a rewritten HeadToHeadSwissPairing class.  Please verify that the calling convention is correct (I tried to document it in the class) and double-check the code.  There may be some PHP shorthand you can use to simplify my code.